### PR TITLE
docs: improve local setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Ensure that the following prerequisites are met before building the 1097 service
 
 * JDK 1.8
 * Maven
+* Node.js v16
 * NPM/YARN
 * Spring Boot v2
 * MySQL
@@ -41,12 +42,23 @@ Ensure that the following prerequisites are met before building the 1097 service
 To install the 1097 module, please follow these steps:
 
 1. Clone the repository to your local machine.
-2. Install the dependencies and build the module:
-   - Run the command `npm install`.
-   - Run the command `npm run build`.
-   - Run the command `mvn clean install`.
-   - Run the command `npm start`.
-3. Open your browser and access `http://localhost:4200/#/login` to view the login page of module.
+2. Install Node.js v16 (recommended via [nvm](https://github.com/nvm-sh/nvm)):
+   ```bash
+   nvm install 16
+   nvm use 16
+   ```
+3. Install the dependencies:
+   ```bash
+   npm config set legacy-peer-deps true
+   npm install node-sass --force
+   npm install --force
+   ```
+4. Configure your local environment by editing `src/environments/environment.local.ts` with your local API URLs.
+5. Start the development server:
+   ```bash
+   npm run dev
+   ```
+6. Open your browser and access `http://localhost:4200/#/login` to view the login page of module.
 
 ## Configuration
 The 1097 module can be configured by editing the config.js file. This file contains all of the settings for the module, such as the database connection string, the user authentication mechanism, and the role hierarchy.

--- a/README.md
+++ b/README.md
@@ -54,11 +54,15 @@ To install the 1097 module, please follow these steps:
    npm install --force
    ```
 4. Configure your local environment by editing `src/environments/environment.local.ts` with your local API URLs.
-5. Start the development server:
+5. Copy the local environment file:
    ```bash
-   npm run dev
+   cp src/environments/environment.local.ts src/environments/environment.ts
    ```
-6. Open your browser and access `http://localhost:4200/#/login` to view the login page of module.
+6. Start the development server:
+   ```bash
+   npm start
+   ```
+7. Open your browser and access `http://localhost:4200/#/login` to view the login page of module.
 
 ## Configuration
 The 1097 module can be configured by editing the config.js file. This file contains all of the settings for the module, such as the database connection string, the user authentication mechanism, and the role hierarchy.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "ng": "ng",
   "postinstall": "node version.js",
   "start": "node version.js && ng serve -o",
-  "dev": "node version.js && ng serve -o --env=local",
   "build": "ng build",
   "test": "ng test",
   "lint": "ng lint",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "ng": "ng",
   "postinstall": "node version.js",
   "start": "node version.js && ng serve -o",
+  "dev": "node version.js && ng serve -o --env=local",
   "build": "ng build",
   "test": "ng test",
   "lint": "ng lint",
@@ -57,9 +58,9 @@
   "sass-loader": "6.0.5",
   "socket.io-client": "2.0.4",
   "tether": "1.4.0",
+  "uglify-js": "2.8.29",
   "xlsx": "0.13.0",
-  "zone.js": "0.8.11",
-  "uglify-js": "2.8.29"
+  "zone.js": "0.8.11"
  },
  "devDependencies": {
   "@angular/cdk": "2.0.0-beta.11",
@@ -87,8 +88,8 @@
   "ts-node": "3.3.0",
   "tslint": "5.7.0",
   "typescript": "2.4.0",
-  "xlsx": "0.13.0",
-  "uglify-js": "2.8.29"
+  "uglify-js": "2.8.29",
+  "xlsx": "0.13.0"
  },
  "resolutions": {
   "@types/geojson": "7946.0.8"


### PR DESCRIPTION
## Summary
- Updated README prerequisites to specify Node.js v16
- Improved installation steps with correct `npm install` sequence (matching CI workflow)
- Added explicit step to copy `environment.local.ts` to `environment.ts` before running `npm start`

Issue: PSMRI/AMRIT#111