### PR TITLE
fix: auto-load history and fetch subcategory details in CO services

### DIFF
--- a/src/app/co-counselling-services/co-counselling-services.component.ts
+++ b/src/app/co-counselling-services/co-counselling-services.component.ts
@@ -92,6 +92,9 @@ export class CoCounsellingServicesComponent implements OnInit, DoCheck {
     this.assignSelectedLanguage();
     this.providerServiceMapID = this.saved_data.current_service.serviceID;
     this.GetServiceTypes();
+    if (this.beneficiaryID) {
+      this.GetCounsellingHistory();
+    }
   }
 
   setBenRegID(data) {
@@ -174,13 +177,19 @@ export class CoCounsellingServicesComponent implements OnInit, DoCheck {
     this.getDetailsFlag = false;
   }
 
- GetSubCategoryDetails(id: any) {
-    this.enableFileDetails = true;   
-    this.showresult = true;      
+  GetSubCategoryDetails(id: any) {
+    this.enableFileDetails = true;
+    this.showresult = true;
     this.subCategoryID = id;
-
-    // Find the subcategory from the list
     this.subcategoryOBJ = this.subCategoryList.find(item => item.subCategoryID === id) || null;
+
+    this._coCategoryService.getCODetails(
+      id, this.saved_data.uname, this.beneficiaryID, this.serviceID,
+      this.symptomCategory, this.saved_data.callData.benCallID
+    ).subscribe(
+      response => this.SetSubCategoryDetails(response),
+      err => this.alertService.alert(err.errorMessage, 'error')
+    );
   }
   
   EnabledGetDetails() {

--- a/src/app/co-feedback-services/co-feedback-services.component.ts
+++ b/src/app/co-feedback-services/co-feedback-services.component.ts
@@ -153,7 +153,9 @@ export class CoFeedbackServicesComponent implements OnInit {
     this.dec2014 = new Date(2014, 11, 1, 0, 0, 0);
     this.GetInstitutes();
     this.assignSelectedLanguage();
-
+    if (this.beneficiaryRegID) {
+      this.showBeneficiaryFeedbackList();
+    }
   }
   tempFlag: any;
 

--- a/src/app/co-information-services/co-information-services.component.ts
+++ b/src/app/co-information-services/co-information-services.component.ts
@@ -73,24 +73,23 @@ export class CoInformationServicesComponent implements OnInit {
     private _coCategoryService: CoCategoryService,
     private saved_data: dataService,
     private _coService: CoReferralService,
-    private pass_data: CommunicationService, 
-    public alertService: ConfirmationDialogsService, 
+    private pass_data: CommunicationService,
+    public alertService: ConfirmationDialogsService,
     public HttpServices: HttpServices,
   ) {
-    this.subscription = this.pass_data.getData().subscribe(message => { this.getData(message) });
     this.saved_data.beneficiary_regID_subject.subscribe(response => {
       this.setBenRegID(response);
     });
-    // saved_data.myBool$.subscribe((newBool: boolean) => { alert("new val in co info",newBool) });
   }
   ngOnInit() {
     this.assignSelectedLanguage();
     this.subscription = this.pass_data.getData().subscribe(message => { this.getData(message) });
-    
-    this.providerServiceMapID = this.saved_data.current_service.serviceID;
-    // Add here
-    this.GetServiceTypes();
 
+    this.providerServiceMapID = this.saved_data.current_service.serviceID;
+    this.GetServiceTypes();
+    if (this.beneficiaryID) {
+      this.GetInformationHistory();
+    }
   }
    ngDoCheck() {
     this.assignSelectedLanguage();
@@ -180,12 +179,18 @@ export class CoInformationServicesComponent implements OnInit {
   }
 
   GetSubCategoryDetails(id: any) {
-    this.enableFileDetails = true;   
-    this.showresult = true;      
+    this.enableFileDetails = true;
+    this.showresult = true;
     this.subCategoryID = id;
-
-    // Find the subcategory from the list
     this.subcategoryOBJ = this.subCategoryList.find(item => item.subCategoryID === id) || null;
+
+    this._coCategoryService.getDetails(
+      id, this.saved_data.uname, this.beneficiaryID, this.subServiceID,
+      this.symptomCategory, this.saved_data.callData.benCallID
+    ).subscribe(
+      response => this.SetSubCategoryDetails(response),
+      err => this.alertService.alert(err.errorMessage, 'error')
+    );
   }
 
  

--- a/src/app/co-referral-services/co-referral-services.component.ts
+++ b/src/app/co-referral-services/co-referral-services.component.ts
@@ -115,6 +115,9 @@ export class CoReferralServicesComponent implements OnInit {
         this.message.alert(err.errorMessage, 'error');
       });
     this.GetInformationDirectory();
+    if (this.beneficiaryRegID) {
+      this.setBeneficiaryData();
+    }
   }
    ngDoCheck() {
     this.assignSelectedLanguage();


### PR DESCRIPTION


## 📋 Description

JIRA ID: 

AMM-2303
---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information
2.1097 service mapping is missing, like information services, counseling, referral services and feedback services.
- Load counselling/information/feedback/referral history automatically on component init when a beneficiaryID is already available, so returning agents see prior data without a manual trigger.
- Call the getCODetails / getDetails API inside GetSubCategoryDetails instead of only updating local state, so subcategory content is fetched from the server on selection..
