### PR TITLE
fix: replace fdescribe with describe in test files to enable full test suite

### DIFF
--- a/src/app/supervisor-alerts-notifications/supervisor-alerts-notifications.component.spec.ts
+++ b/src/app/supervisor-alerts-notifications/supervisor-alerts-notifications.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -108,7 +108,7 @@ function Initialize104TestBed() {
 }
 describe('Supervisor-alerts-notifications', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104TestBed();
 

--- a/src/app/supervisor-emergency-contacts/supervisor-emergency-contacts.component.spec.ts
+++ b/src/app/supervisor-emergency-contacts/supervisor-emergency-contacts.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -104,7 +104,7 @@ function Initialize104TestBed() {
 }
 describe('Supervisor-emergency-contacts', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104TestBed();
 

--- a/src/app/supervisor-location-communication/supervisor-location-communication.component.spec.ts
+++ b/src/app/supervisor-location-communication/supervisor-location-communication.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -101,7 +101,7 @@ function Initialize104TestBed() {
 }
 describe('Supervisor-location-communication', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104TestBed();
 

--- a/src/app/supervisor-training-resources/supervisor-training-resources.component.spec.ts
+++ b/src/app/supervisor-training-resources/supervisor-training-resources.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -107,7 +107,7 @@ function Initialize104coTestBed() {
 
 describe('Supervisor-Training-resources', () => {
 
-    fdescribe('When the component is getting loaded, then ngOninit', () => {
+    describe('When the component is getting loaded, then ngOninit', () => {
 
         Initialize104coTestBed();
 


### PR DESCRIPTION
## 📋 Description

Fixes test configuration bug in Helpline1097-UI where `fdescribe()` was used in 4 supervisor module spec files instead of `describe()`.

`fdescribe()` is Jasmine's focused describe — it silently skips ALL other tests, giving false CI confidence. 
The full test suite was not running on these modules.

Explicitly forbidden in `tslint.json` but present in supervisor specs.

Related to PSMRI/AMRIT#128 (C4GT DMP 2026 — Helpline1097-UI migration)

## ✅ Type of Change
- [x] 🐞 Bug fix
- [x] 🧪 Tests

## ℹ️ Additional Information
- 4 supervisor spec files fixed
- Zero logic changes
- Full test suite now runs correctly