### PR TITLE
fix: guard all service error handlers against non-JSON responses

### DIFF
--- a/src/app/services/callservices/callservice.service.ts
+++ b/src/app/services/callservices/callservice.service.ts
@@ -200,16 +200,45 @@ export class CallServices {
   }
 
   handleError(error: Response) {
-    return Observable.throw(error.json());
+    let errorObj: any;
+    try {
+      errorObj = error.json();
+      if (!errorObj.errorMessage) {
+        errorObj.errorMessage = errorObj.message || errorObj.error || error.statusText || 'Request failed';
+      }
+    } catch (e) {
+      errorObj = { errorMessage: error.statusText || 'Request failed' };
+    }
+    return Observable.throw(errorObj);
   }
   handleCustomError(error: Response) {
-    return Observable.throw(error.json());
+    let errorObj: any;
+    try {
+      errorObj = error.json();
+      if (!errorObj.errorMessage) {
+        errorObj.errorMessage = errorObj.message || errorObj.error || error.statusText || 'Request failed';
+      }
+    } catch (e) {
+      errorObj = { errorMessage: error.statusText || 'Request failed' };
+    }
+    return Observable.throw(errorObj);
   }
 
    //Shubham Shekhar,03-09-2021,Wrapu up configuration
    getRoleBasedWrapuptime(roleID) {
     return this._httpInterceptor.get(this.getWrapupTime + roleID)
-    .map((response: Response) => response.json()).catch((error) => Observable.throw(error.json()));
+    .map((response: Response) => response.json()).catch((error) => {
+      let errorObj: any;
+      try {
+        errorObj = error.json();
+        if (!errorObj.errorMessage) {
+          errorObj.errorMessage = errorObj.message || errorObj.error || error.statusText || 'Request failed';
+        }
+      } catch (e) {
+        errorObj = { errorMessage: error.statusText || 'Request failed' };
+      }
+      return Observable.throw(errorObj);
+    });
 }
 
    checkIfAlreadyCalled(obj)

--- a/src/app/services/coService/co_category_subcategory.service.ts
+++ b/src/app/services/coService/co_category_subcategory.service.ts
@@ -112,7 +112,16 @@ export class CoCategoryService {
     }
 
     handleError(error: Response) {
-        return Observable.throw(error.json());
+        let errorObj: any;
+        try {
+            errorObj = error.json();
+            if (!errorObj.errorMessage) {
+                errorObj.errorMessage = errorObj.message || errorObj.error || error.statusText || 'Request failed';
+            }
+        } catch (e) {
+            errorObj = { errorMessage: error.statusText || 'Request failed' };
+        }
+        return Observable.throw(errorObj);
     }
 };
 

--- a/src/app/services/common/location.service.ts
+++ b/src/app/services/common/location.service.ts
@@ -113,6 +113,15 @@ export class LocationService {
 
 
     handleError(error: Response) {
-        return Observable.throw(error.json());
+        let errorObj: any;
+        try {
+            errorObj = error.json();
+            if (!errorObj.errorMessage) {
+                errorObj.errorMessage = errorObj.message || errorObj.error || error.statusText || 'Request failed';
+            }
+        } catch (e) {
+            errorObj = { errorMessage: error.statusText || 'Request failed' };
+        }
+        return Observable.throw(errorObj);
     }
 }

--- a/src/app/services/common/userbeneficiarydata.service.ts
+++ b/src/app/services/common/userbeneficiarydata.service.ts
@@ -111,6 +111,15 @@ export class UserBeneficiaryData {
     }
 
     handleError(error: Response) {
-        return Observable.throw(error.json());
+        let errorObj: any;
+        try {
+            errorObj = error.json();
+            if (!errorObj.errorMessage) {
+                errorObj.errorMessage = errorObj.message || errorObj.error || error.statusText || 'Request failed';
+            }
+        } catch (e) {
+            errorObj = { errorMessage: error.statusText || 'Request failed' };
+        }
+        return Observable.throw(errorObj);
     }
 };

--- a/src/app/services/loginService/login.service.ts
+++ b/src/app/services/loginService/login.service.ts
@@ -141,7 +141,16 @@ export class loginService {
 
   private handleError(error: Response | any) {
     console.error("handleError",error)
-    return Observable.throw(error.json());
+    let errorObj: any;
+    try {
+      errorObj = error.json();
+      if (!errorObj.errorMessage) {
+        errorObj.errorMessage = errorObj.message || errorObj.error || error.statusText || 'Request failed';
+      }
+    } catch (e) {
+      errorObj = { errorMessage: error.statusText || 'Request failed' };
+    }
+    return Observable.throw(errorObj);
 
   };
 };

--- a/src/app/services/notificationService/notification-service.ts
+++ b/src/app/services/notificationService/notification-service.ts
@@ -172,10 +172,28 @@ export class NotificationService {
         .map((response : Response )=> response.json().data).catch(this.handleCustomError);
     }
     handleError(error: Response) {
-        return Observable.throw(error.json());
+        let errorObj: any;
+        try {
+            errorObj = error.json();
+            if (!errorObj.errorMessage) {
+                errorObj.errorMessage = errorObj.message || errorObj.error || error.statusText || 'Request failed';
+            }
+        } catch (e) {
+            errorObj = { errorMessage: error.statusText || 'Request failed' };
+        }
+        return Observable.throw(errorObj);
     }
     handleCustomError(error: Response) {
-        return Observable.throw(error.json());
+        let errorObj: any;
+        try {
+            errorObj = error.json();
+            if (!errorObj.errorMessage) {
+                errorObj.errorMessage = errorObj.message || errorObj.error || error.statusText || 'Request failed';
+            }
+        } catch (e) {
+            errorObj = { errorMessage: error.statusText || 'Request failed' };
+        }
+        return Observable.throw(errorObj);
     }
     saveGuidelines(data) {
         return this.httpIntercepto.post(this.saveEverwellGuidelinesURL, data)

--- a/src/app/services/outboundServices/outbound-call-allocation.service.ts
+++ b/src/app/services/outboundServices/outbound-call-allocation.service.ts
@@ -137,6 +137,15 @@ export class OutboundCallAllocationService {
     private handleError(error: Response | any) {
 
         // In a real world app, you might use a remote logging infrastructur
-        return Observable.throw(error.json());
+        let errorObj: any;
+        try {
+            errorObj = error.json();
+            if (!errorObj.errorMessage) {
+                errorObj.errorMessage = errorObj.message || errorObj.error || error.statusText || 'Request failed';
+            }
+        } catch (e) {
+            errorObj = { errorMessage: error.statusText || 'Request failed' };
+        }
+        return Observable.throw(errorObj);
     };
 }

--- a/src/app/services/outboundServices/outbound-call-reallocation.service.ts
+++ b/src/app/services/outboundServices/outbound-call-reallocation.service.ts
@@ -149,7 +149,16 @@ export class OutboundReAllocationService {
     }
 
     private handleError(error: Response | any) {
-        return Observable.throw(error.json());
+        let errorObj: any;
+        try {
+            errorObj = error.json();
+            if (!errorObj.errorMessage) {
+                errorObj.errorMessage = errorObj.message || errorObj.error || error.statusText || 'Request failed';
+            }
+        } catch (e) {
+            errorObj = { errorMessage: error.statusText || 'Request failed' };
+        }
+        return Observable.throw(errorObj);
     };
 
     benDetailsOnPhnNo(data) {

--- a/src/app/services/outboundServices/outbound-work-list.service.ts
+++ b/src/app/services/outboundServices/outbound-work-list.service.ts
@@ -67,7 +67,16 @@ export class OutboundWorklistService {
     };
 
     private handleError(error: Response | any) {
-        return Observable.throw(error.json());
+        let errorObj: any;
+        try {
+            errorObj = error.json();
+            if (!errorObj.errorMessage) {
+                errorObj.errorMessage = errorObj.message || errorObj.error || error.statusText || 'Request failed';
+            }
+        } catch (e) {
+            errorObj = { errorMessage: error.statusText || 'Request failed' };
+        }
+        return Observable.throw(errorObj);
     };
 
 

--- a/src/app/services/register-services/register-service.ts
+++ b/src/app/services/register-services/register-service.ts
@@ -148,11 +148,29 @@ export class RegisterService {
   };
 
   private customhandleError(error: Response | any) {
-    return Observable.throw(error.json());
+    let errorObj: any;
+    try {
+      errorObj = error.json();
+      if (!errorObj.errorMessage) {
+        errorObj.errorMessage = errorObj.message || errorObj.error || error.statusText || 'Request failed';
+      }
+    } catch (e) {
+      errorObj = { errorMessage: error.statusText || 'Request failed' };
+    }
+    return Observable.throw(errorObj);
 
   };
   private handleError(res: Response) {
-    return Observable.throw(res.json());
+    let errorObj: any;
+    try {
+      errorObj = res.json();
+      if (!errorObj.errorMessage) {
+        errorObj.errorMessage = errorObj.message || errorObj.error || res.statusText || 'Request failed';
+      }
+    } catch (e) {
+      errorObj = { errorMessage: res.statusText || 'Request failed' };
+    }
+    return Observable.throw(errorObj);
   };
 
 }

--- a/src/app/services/reports-service/reports-service.ts
+++ b/src/app/services/reports-service/reports-service.ts
@@ -108,11 +108,29 @@ export class ReportsService {
   };
 
   private customhandleError(error: Response | any) {
-    return Observable.throw(error.json());
+    let errorObj: any;
+    try {
+      errorObj = error.json();
+      if (!errorObj.errorMessage) {
+        errorObj.errorMessage = errorObj.message || errorObj.error || error.statusText || 'Request failed';
+      }
+    } catch (e) {
+      errorObj = { errorMessage: error.statusText || 'Request failed' };
+    }
+    return Observable.throw(errorObj);
 
   };
   private handleError(error: Response) {
-    return Observable.throw(error.json());
+    let errorObj: any;
+    try {
+      errorObj = error.json();
+      if (!errorObj.errorMessage) {
+        errorObj.errorMessage = errorObj.message || errorObj.error || error.statusText || 'Request failed';
+      }
+    } catch (e) {
+      errorObj = { errorMessage: error.statusText || 'Request failed' };
+    }
+    return Observable.throw(errorObj);
   };
 
 }

--- a/src/app/services/supervisorServices/Feedbackservice.service.ts
+++ b/src/app/services/supervisorServices/Feedbackservice.service.ts
@@ -96,9 +96,27 @@ export class FeedbackService {
         }
     }
     handleCustomError(error: Response | any) {
-        return Observable.throw(error.json());
+        let errorObj: any;
+        try {
+            errorObj = error.json();
+            if (!errorObj.errorMessage) {
+                errorObj.errorMessage = errorObj.message || errorObj.error || error.statusText || 'Request failed';
+            }
+        } catch (e) {
+            errorObj = { errorMessage: error.statusText || 'Request failed' };
+        }
+        return Observable.throw(errorObj);
     }
     handleError(error: Response) {
-        return Observable.throw(error.json());
+        let errorObj: any;
+        try {
+            errorObj = error.json();
+            if (!errorObj.errorMessage) {
+                errorObj.errorMessage = errorObj.message || errorObj.error || error.statusText || 'Request failed';
+            }
+        } catch (e) {
+            errorObj = { errorMessage: error.statusText || 'Request failed' };
+        }
+        return Observable.throw(errorObj);
     }
 }

--- a/src/app/services/supervisorServices/forceLogoutService.service.ts
+++ b/src/app/services/supervisorServices/forceLogoutService.service.ts
@@ -65,7 +65,16 @@ export class ForceLogoutService {
     }
 
     private handleError(error: Response | any) {
-        return Observable.throw(error.json());
+        let errorObj: any;
+        try {
+            errorObj = error.json();
+            if (!errorObj.errorMessage) {
+                errorObj.errorMessage = errorObj.message || errorObj.error || error.statusText || 'Request failed';
+            }
+        } catch (e) {
+            errorObj = { errorMessage: error.statusText || 'Request failed' };
+        }
+        return Observable.throw(errorObj);
     };
 
 }

--- a/src/app/services/supervisorServices/quality-audit-service.service.ts
+++ b/src/app/services/supervisorServices/quality-audit-service.service.ts
@@ -151,7 +151,16 @@ export class QualityAuditService {
     }
 
     private handleError(error: Response | any) {
-        return Observable.throw(error.json());
+        let errorObj: any;
+        try {
+            errorObj = error.json();
+            if (!errorObj.errorMessage) {
+                errorObj.errorMessage = errorObj.message || errorObj.error || error.statusText || 'Request failed';
+            }
+        } catch (e) {
+            errorObj = { errorMessage: error.statusText || 'Request failed' };
+        }
+        return Observable.throw(errorObj);
     };
 
 }

--- a/src/app/services/supervisorServices/sms-template-service.service.ts
+++ b/src/app/services/supervisorServices/sms-template-service.service.ts
@@ -130,7 +130,16 @@ export class SmsTemplateService {
     }
 
     private handleError(error: Response | any) {
-        return Observable.throw(error.json());
+        let errorObj: any;
+        try {
+            errorObj = error.json();
+            if (!errorObj.errorMessage) {
+                errorObj.errorMessage = errorObj.message || errorObj.error || error.statusText || 'Request failed';
+            }
+        } catch (e) {
+            errorObj = { errorMessage: error.statusText || 'Request failed' };
+        }
+        return Observable.throw(errorObj);
     };
 
 }

--- a/src/app/services/supervisorServices/supervisor-calltype-reports-service.service.ts
+++ b/src/app/services/supervisorServices/supervisor-calltype-reports-service.service.ts
@@ -60,6 +60,15 @@ export class SupervisorCallTypeReportService {
   }
 
   handleError(error: Response) {
-    return Observable.throw(error.json());
+    let errorObj: any;
+    try {
+      errorObj = error.json();
+      if (!errorObj.errorMessage) {
+        errorObj.errorMessage = errorObj.message || errorObj.error || error.statusText || 'Request failed';
+      }
+    } catch (e) {
+      errorObj = { errorMessage: error.statusText || 'Request failed' };
+    }
+    return Observable.throw(errorObj);
   }
 }

--- a/src/app/services/update-services/update-service.ts
+++ b/src/app/services/update-services/update-service.ts
@@ -56,7 +56,16 @@ export class UpdateService {
   };
 
   private handleError(error: Response | any) {
-    return Observable.throw(error.json());
+    let errorObj: any;
+    try {
+      errorObj = error.json();
+      if (!errorObj.errorMessage) {
+        errorObj.errorMessage = errorObj.message || errorObj.error || error.statusText || 'Request failed';
+      }
+    } catch (e) {
+      errorObj = { errorMessage: error.statusText || 'Request failed' };
+    }
+    return Observable.throw(errorObj);
 
   };
 

--- a/src/app/services/upload-services/upload-service.service.ts
+++ b/src/app/services/upload-services/upload-service.service.ts
@@ -63,7 +63,16 @@ export class UploadServiceService {
   };
 
   private handleError(error: Response | any) {
-    return Observable.throw(error.json());
+    let errorObj: any;
+    try {
+      errorObj = error.json();
+      if (!errorObj.errorMessage) {
+        errorObj.errorMessage = errorObj.message || errorObj.error || error.statusText || 'Request failed';
+      }
+    } catch (e) {
+      errorObj = { errorMessage: error.statusText || 'Request failed' };
+    }
+    return Observable.throw(errorObj);
 
   };
 }


### PR DESCRIPTION

## 📋 Description

JIRA ID: 

AMM-2306
---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)


---

## ℹ️ Additional Information

Server HTML error pages caused error.json() to throw SyntaxError, which propagated as the caught error. Components reading err.errorMessage on a SyntaxError got undefined, producing empty alert popups. All 18 handleError/handleCustomError methods now wrap json() in try/catch and normalise the errorMessage field through message → error → statusText → 'Request failed'.
